### PR TITLE
Fix unexpected keyword argument 'output_type' in format_record

### DIFF
--- a/ark-demo/pipelines/nfhl/nfhl_pipeline.py
+++ b/ark-demo/pipelines/nfhl/nfhl_pipeline.py
@@ -114,7 +114,7 @@ def run(pipeline_args, gcs_url, layer=None, dataset=None):
              | 'MakeValid ' + layer >> beam.Map(make_valid)
              | 'FilterInvalid ' + layer >> beam.Filter(filter_invalid)
              | 'FormatGDBDatetimes ' + layer >> beam.Map(format_gdb_datetime, layer_schema)
-             | 'FormatRecord ' + layer >> beam.Map(format_record, output_type='geojson')
+             | 'FormatRecord ' + layer >> beam.Map(format_record)
              | 'WriteToBigQuery ' + layer >> beam.io.WriteToBigQuery(
                    beam_bigquery.TableReference(projectId='geo-solution-demos', datasetId=dataset, tableId=layer),
                    method=beam.io.WriteToBigQuery.Method.FILE_LOADS,


### PR DESCRIPTION
Geobeams current release no longer accepts the keyword argument output_type in calls to format_record. It now defaults to geojson, which is what we wanted and what BigQuery expects.